### PR TITLE
Correct default serial device settings

### DIFF
--- a/RexSimulator/Hardware/Rex/SerialIO.cs
+++ b/RexSimulator/Hardware/Rex/SerialIO.cs
@@ -12,7 +12,7 @@ namespace RexSimulator.Hardware.Rex
         /// <summary>
         /// Set this to the board's primary clock rate. It is used to determine how many clock cycles are required to transmit/receive serial data.
         /// </summary>
-        private readonly uint SYSTEM_CLOCK_RATE = 4000000;
+        private readonly uint SYSTEM_CLOCK_RATE = 6250000;
         #endregion
 
         #region Member Variables
@@ -182,7 +182,7 @@ namespace RexSimulator.Hardware.Rex
             {
                 mMemory[i] = 0;
             }
-            Control = 0xC5; //8 data bits, no parity, 1 stop bit, 9600 baud
+            Control = 0xC7; //8 data bits, no parity, 1 stop bit, 38400 baud
             Status = 0x02;
             Interrupt(false);
         }

--- a/RexSimulator/Properties/AssemblyInfo.cs
+++ b/RexSimulator/Properties/AssemblyInfo.cs
@@ -32,5 +32,5 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers 
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("3.1.0")]
-[assembly: AssemblyFileVersion("3.1.0")]
+[assembly: AssemblyVersion("3.1.1")]
+[assembly: AssemblyFileVersion("3.1.1")]

--- a/RexSimulatorGui/Properties/AssemblyInfo.cs
+++ b/RexSimulatorGui/Properties/AssemblyInfo.cs
@@ -32,5 +32,5 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers 
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("3.2.0")]
-[assembly: AssemblyFileVersion("3.2.0")]
+[assembly: AssemblyVersion("3.2.1")]
+[assembly: AssemblyFileVersion("3.2.1")]


### PR DESCRIPTION
The new boards run their serial devices at 38400 baud. While this setting is changed by WRAMPmon during normal operation, that doesn't happen if the RexSimulator project is run independently as a library.  
The serial device was also built to run as though the clock rate was still 4MHz, rather than the new 6.25MHz. This could not be changed by configuration, so the serial device should correctly be a little faster now (which is also good when running as a library!).