### PR TITLE
Release v3.3.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Change History for wsim and rexsim
 
+## 3.3.3
+
+* The duck can only quack once at a time
+  * This makes it sound a lot better when clicking on it
+  * It also fixes a bug reported by Liam Jamieson, where making a program which continually sends
+    the bell character to the serial port will cause the simulator to use all your CPU and quack
+    uncontrollably. This was caused by the fact that a new SoundPlayer was created every time a
+    bell was sent, loading the resource again and sending a new call to the sound API. Now, there
+    is a single SoundPlayer which has a timeout, enforced by the new Quacker class which has a
+    single instance passed around.
+
 ## 3.3.2
 
 * Memory form is wide enough to see the \[B\] mark when a breakpoint is set

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,38 @@
-# Change History for rexsim
+# Change History for wsim and rexsim
+
+## 3.3.2
+
+* Memory form is wide enough to see the \[B\] mark when a breakpoint is set
+* The Run button functions when on a breakpoint
+* Documentation updates
+
+## 3.3.1
+
+* Update WRAMPmon to 0.9
+* Stop text in the serial port form being invisible when the program is run under a dark theme
+* Stop the program crashing on certain invalid escape sequences which place the cursor out of bounds
+* User mode warning colour disappears correctly when switched off
+* Serial interrupt register TDS is set correctly
+
+## 3.3.0
+
+* Updates RexSimulator module to v3.1.2
+  * Timer is set up for the new 6.25MHz clock
+* Improve memory form performance when a lot of changes occur
+* Stepping over breakpoints works properly
+* Hard reset (upper right red button) also resets switches
+* Serial port bell quacks instead of beeping
+
+## 3.2.1
+
+* Updates RexSimulator module to v3.1.1
+* Corrects the speed of the serial devices to account for environments which don't run WRAMPmon, and the new clockrate.
+
+## 3.2.0
+
+* FEATURE: The program version is displayed in the status bar at the bottom. When clicked, an about dialog will appear.
+* BUGFIX: Controls now scale correctly on both Windows and Linux. This was fixed by disabling scaling.
+* The assembly info has been changed to more correctly display ownership, and visual branding has been changed to wsim rather than RexSimulator. Most of the code and the AssemblyTitle still refer to RexSimulator.
 
 ## 3.1.0
 

--- a/README.md
+++ b/README.md
@@ -1,18 +1,22 @@
-# Wsim (Formerly rexsim)
+# [wsim](https://github.com/wandwramp/wsim) (Formerly rexsim)
 
-This project is a full simulator of the WRAMP (Waikato RISC Architecture
-MicroProcessor) CPU used at the University of Waikato for teaching computer
-architecture concepts, along with the Basys 3 FPGA that contains the CPU.
+This project is a full simulator of the [WRAMP](https://wramp.wand.nz/) 
+(Waikato RISC Architecture MicroProcessor) CPU used at the University of 
+Waikato for teaching computer architecture concepts, along with the Basys 
+3 FPGA that contains the CPU.
 
-Prior versions of this software simulated the Rex board which held an older
-version of the hardware, while this version simulates the reimplementation.
-It was updated in tandem with the creation of the reimplementation, so it
-should accurately reflect the behaviour of the hardware.
+Prior versions of this software, written by Paul Monigatti, simulated the 
+Rex board which held an older version of the hardware, while this version 
+simulates the reimplementation. It was updated in tandem with the creation 
+of the reimplementation, so it should accurately reflect the behaviour of 
+the hardware.
 
 ## Usage
 
-Running wim requires `mono` to be installed.
-It has been tested under mono v4.2.1.0, with XBuild Engine Version 12.0.
+Running wim under Linux (and probably Mac OS, though it hasn't been tested)
+requires `mono` to be installed. There have been no compatibility issues 
+reported, so any reasonably recent version should work. It should also work
+on Windows.
 
 Either double-clicking `RexSimulatorGui/bin/Debug/RexSimulatorGui.exe` or
 running `$ mono RexSimulatorGui.exe` will launch the program.
@@ -20,11 +24,11 @@ running `$ mono RexSimulatorGui.exe` will launch the program.
 On first open, two windows will appear: The main board, and the first serial
 port. This serial port is used for communication with WRAMPmon. Type `?` for
 help, or simply run `load` to upload a program file. Dragging an .srec into the
-serial port window will send it, even though the prompt tells you to press
-CTRL-A S. You can also press CTRL-A to open the `Send File` dialog. Typing `go`
-after a file is loaded will run it.
+serial port window will send it, or you can press CTRL-A to open the `Send File`
+dialog and browse for your .srec file. Typing `go` after a file is loaded will 
+run it.
 
-The board's physical ports can be interacted with using the main window, and
+The board's physical interfaces can be interacted with using the main window, and
 the tick boxes at the bottom of the window will open other useful windows. See
 the Debugging section below for more details.
 

--- a/RexSimulatorGui/Controls/RexWidget.cs
+++ b/RexSimulatorGui/Controls/RexWidget.cs
@@ -114,6 +114,7 @@ namespace RexSimulatorGui.Controls
 
         
         private ControlWithFocus mActiveControl = ControlWithFocus.None;
+        private Quacker quacker;
         #endregion
 
         public RexWidget()
@@ -453,8 +454,10 @@ namespace RexSimulatorGui.Controls
                     break;
 
                 case ControlWithFocus.Duck:
-                    SoundPlayer sp = new SoundPlayer(Resources.duck_quack);
-                    sp.Play();
+                    if (quacker != null) 
+                    {
+                        quacker.Quack();
+                    }
                     break;
             }
 
@@ -497,6 +500,14 @@ namespace RexSimulatorGui.Controls
         public void LoadSrec(Stream stream)
         {
             mBoard.LoadSrec(stream);
+        }
+
+        /// <summary>
+        /// Sets the quacker to use to play sound.
+        /// </summary>
+        public void SetQuacker(Quacker _quacker)
+        {
+            quacker = _quacker;
         }
         #endregion
     }

--- a/RexSimulatorGui/Forms/BasicSerialPortForm.cs
+++ b/RexSimulatorGui/Forms/BasicSerialPortForm.cs
@@ -45,6 +45,7 @@ namespace RexSimulatorGui.Forms
         #endregion
 
         #region Member Vars
+        private Quacker quacker;
         private SerialIO mSerialPort;
         private Thread mUploadFileWorker;
         private StringBuilder mRecvBuffer;
@@ -255,9 +256,12 @@ namespace RexSimulatorGui.Forms
             {
                 switch (c)
                 {
+                    // This is the bell character. It quacks.
                     case (char)0x07:
-                        SoundPlayer sp = new SoundPlayer(Resources.duck_quack);
-                        sp.Play();
+                        if (quacker != null) 
+                        {
+                            quacker.Quack();
+                        }
                         break;
 
                     case '\r':
@@ -442,6 +446,14 @@ namespace RexSimulatorGui.Forms
         {
             if (mUploadFileWorker != null && mUploadFileWorker.ThreadState == System.Threading.ThreadState.Running)
                 mUploadFileWorker.Abort();
+        }
+
+        /// <summary>
+        /// Sets the quacker to use to play sound.
+        /// </summary>
+        public void SetQuacker(Quacker _quacker)
+        {
+            quacker = _quacker;
         }
         #endregion
     }

--- a/RexSimulatorGui/Forms/RexBoardForm.cs
+++ b/RexSimulatorGui/Forms/RexBoardForm.cs
@@ -30,6 +30,7 @@ using RexSimulatorGui.Properties;
 using System.Threading;
 using RexSimulator.Hardware.Wramp;
 using System.Reflection;
+using System.Media;
 
 namespace RexSimulatorGui.Forms
 {
@@ -109,6 +110,11 @@ namespace RexSimulatorGui.Forms
             mParallelConfigForm = new PeripheralMemoryForm(mRexBoard.Parallel);
             mTimerConfigForm = new PeripheralMemoryForm(mRexBoard.Timer);
             
+            // All the sound sources share a single quacker to ensure there's no overlap.
+            Quacker quacker = new Quacker(Resources.duck_quack);
+            rexWidget1.SetQuacker(quacker);
+            mSerialForm1.SetQuacker(quacker);
+            mSerialForm2.SetQuacker(quacker);
 
             //Add all forms to the list of subforms
             mSubforms.Add(mSerialForm1);

--- a/RexSimulatorGui/Properties/AssemblyInfo.cs
+++ b/RexSimulatorGui/Properties/AssemblyInfo.cs
@@ -31,7 +31,7 @@ using System.Runtime.InteropServices;
 [assembly: AssemblyConfiguration("")]
 [assembly: AssemblyCompany("WAND, University of Waikato")]
 [assembly: AssemblyProduct("RexSimulatorGui")]
-[assembly: AssemblyCopyright("Copyright 2019 University of Waikato")]
+[assembly: AssemblyCopyright("Copyright 2019-2021 University of Waikato")]
 [assembly: AssemblyTrademark("")]
 [assembly: AssemblyCulture("")]
 
@@ -53,5 +53,5 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers 
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("3.3.2")]
-[assembly: AssemblyFileVersion("3.3.2")]
+[assembly: AssemblyVersion("3.3.3")]
+[assembly: AssemblyFileVersion("3.3.3")]

--- a/RexSimulatorGui/Quacker.cs
+++ b/RexSimulatorGui/Quacker.cs
@@ -1,0 +1,53 @@
+using System;
+using System.IO;
+using System.Media;
+using System.Reflection;
+using System.Timers;
+using System.Diagnostics;
+using System.Runtime.InteropServices;
+
+namespace RexSimulatorGui
+{
+    /// <summary>
+    /// Encapsulates SoundPlayer, only allowing the loaded resource
+    /// to play once at a time. Since we only have one sound in this
+    /// program, we just make it work for that sound and nothing else.
+    /// </summary>
+    public class Quacker
+    {
+        // duck_quack.wav lasts 178ms according to Audacity
+        private Timer timer = new Timer(178);
+        private SoundPlayer player;
+
+        private volatile bool isPlaying = false;
+        public bool IsPlaying
+        {
+            get
+            {
+                return isPlaying;
+            }
+        }
+
+        public Quacker(Stream resource)
+        {
+            player = new SoundPlayer(resource);
+            player.Load();
+            timer.Elapsed += StoppedPlaying;
+        }
+
+        private void StoppedPlaying(Object source, ElapsedEventArgs e)
+        {
+            isPlaying = false;
+        }
+
+        public void Quack()
+        {
+            if (!IsPlaying)
+            {
+                isPlaying = true;
+                timer.Start();
+                player.Play();
+            }
+        }
+    }
+}

--- a/RexSimulatorGui/RexSimulatorGui.csproj
+++ b/RexSimulatorGui/RexSimulatorGui.csproj
@@ -91,6 +91,7 @@
       <DependentUpon>RexBoardForm.cs</DependentUpon>
     </Compile>
     <Compile Include="Program.cs" />
+    <Compile Include="Quacker.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <EmbeddedResource Include="Controls\RexWidget.resx">
       <DependentUpon>RexWidget.cs</DependentUpon>


### PR DESCRIPTION
Fixes SoundPlayer usage to drastically improve performance when many sounds are requested in a short time.

This stops the simulator from using all your CPU and quacking uncontrollably when a program is made that sends many bell characters to the serial port. Thanks to Liam Jamieson for reporting the bug. It also makes the quack when clicking on the board sound better.

Also minorly updates the README, and adds changelog entries since v3.2.0.

[wsim-3.3.3.zip](https://github.com/wandwramp/wsim/files/6159645/wsim-3.3.3.zip)
